### PR TITLE
feat!: new persistence api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,4 @@ orama.json
 package-lock.json
 pnpm-lock.yaml
 yarn.lock
+*.msp

--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,4 @@ package-lock.json
 pnpm-lock.yaml
 yarn.lock
 *.msp
+orama_[0-9]*.json

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Continuous Integration](https://github.com/mateonunez/fastify-orama/workflows/ci/badge.svg)
 
-Orama plugin for Fastify.
+[Orama](https://oramasearch.com/) plugin for Fastify.
 
 ## Installation
 
@@ -47,7 +47,8 @@ app.listen(3000)
 
 ## Usage with data persistence
 
-This plugin implements [@oramasearch/plugin-data-persistence](https://github.com/oramasearch/plugin-data-persistence) to allow users to `load` or `save` database instances.
+This plugin implements [`@oramasearch/plugin-data-persistence`](https://docs.oramasearch.com/plugins/plugin-data-persistence)
+to allow users to `load` or `save` database instances.
 
 ### Example
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ app.register(fastifyOrama, {
     quote: "string",
     author: "string"
   },
-  persistency: new PersistenceInFile({
+  persistence: new PersistenceInFile({
     filePath: './db.json', // Default: './orama.msp'
     format: 'json', // Default: 'binary',
     mustExistOnStart: true // Default: false

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ npm install fastify-orama
 
 ```js
 import Fastify from 'fastify'
-import FastifyOrama from 'fastify-orama'
+import fastifyOrama from 'fastify-orama'
 
 const app = Fastify()
 
-await app.register(FastifyOrama, {
+await app.register(fastifyOrama, {
   schema: {
     quote: "string",
     author: "string"
@@ -54,12 +54,12 @@ to allow users to `load` or `save` database instances.
 
 ```js
 import Fastify from 'fastify'
-import FastifyOrama from 'fastify-orama'
+import fastifyOrama from 'fastify-orama'
 
 const app = Fastify()
 
 // The database must exists to load it in your Fastify application
-await app.register(FastifyOrama, {
+await app.register(fastifyOrama, {
   persistence: true,
   persistency: {
     name: './quotes.json',
@@ -90,4 +90,4 @@ app.listen(3000)
 
 ## License
 
-FastifyOrama is licensed under the [MIT](LICENSE) license.
+fastifyOrama is licensed under the [MIT](LICENSE) license.

--- a/README.md
+++ b/README.md
@@ -9,8 +9,16 @@
 ```
 npm install fastify-orama
 ```
+
 ****
+
+
 ## Usage
+
+This plugin adds the `orama` decorator to your Fastify application.
+
+The `options` object is passed directly to the `Orama.create` constructor,
+so it supports [all the options that Orama supports](https://docs.oramasearch.com/usage/create).
 
 ### Example
 
@@ -20,73 +28,155 @@ import fastifyOrama from 'fastify-orama'
 
 const app = Fastify()
 
-await app.register(fastifyOrama, {
+app.register(fastifyOrama, {
   schema: {
     quote: "string",
     author: "string"
   }
 })
 
-app.get('/quotes/:query', async function (req, reply) {
-  try {
-    const { params: { query } } = req
+app.get('/quotes/:query', async function handler (req, reply) {
+  const { params: { query } } = req
 
-    const search = await app.orama.search({
-      term: query,
-      properties: ["quote"]
-    })
+  const search = await app.orama.search({
+    term: query,
+    properties: ["quote"]
+  })
 
-    return { quotes: search.hits }
-  } catch (err) {
-    return err;
-  }
+  return { quotes: search.hits }
 })
 
-app.listen(3000)
+app.listen({ port: 3000 })
 ```
+
 
 ## Usage with data persistence
 
-This plugin implements [`@oramasearch/plugin-data-persistence`](https://docs.oramasearch.com/plugins/plugin-data-persistence)
-to allow users to `load` or `save` database instances.
+This plugin supports data persistence out of the box.
+You need to pass the `persistence` option to the plugin registration!
 
-### Example
+This plugin uses [`@oramasearch/plugin-data-persistence`](https://docs.oramasearch.com/plugins/plugin-data-persistence)
+under the hood to allow users to `load` or `save` database instances.
+
+Turning on the `persistence` option will add the `fastify.orama.save()` method to your Fastify application.
+You must call this method to save the database instance to the persistence layer, otherwise your data will be lost.
+
+### PersistenceInFile
+
+This plugin comes with a `PersistenceInFile` class that allows you to persist your data in a file.
+If the file exists, the plugin will load the data from it when the plugin is registered.
+
+Its constructor accepts the following options:
+
+- `filePath`: The path to the file where the data will be persisted. Default: `./orama.msp`
+- `format`: The format of the file where the data will be persisted. Default: `binary`
+- `mustExistOnStart`: Whether the file must exist when the plugin is registered or not. Default: `false`. Note that if the file does not exist, you must specify the `schema` option in the plugin registration.
+
 
 ```js
 import Fastify from 'fastify'
-import fastifyOrama from 'fastify-orama'
+import { fastifyOrama, PersistenceInFile } from 'fastify-orama'
 
 const app = Fastify()
 
 // The database must exists to load it in your Fastify application
-await app.register(fastifyOrama, {
-  persistence: true,
-  persistency: {
-    name: './quotes.json',
-    format: 'json'
-  }
+app.register(fastifyOrama, {
+  schema: {
+    quote: "string",
+    author: "string"
+  },
+  persistency: new PersistenceInFile({
+    filePath: './db.json', // Default: './orama.msp'
+    format: 'json', // Default: 'binary',
+    mustExistOnStart: true // Default: false
+  })
 })
 
 app.post('/quotes', async function (req, reply) {
-  try {
-    const { body: { author, quote } } = req
+  const { body: { author, quote } } = req
 
-    await fastify.orama.insert({
-      author,
-      quote
-    })
+  await fastify.orama.insert({
+    author,
+    quote
+  })
 
-    await fastify.orama.save()
-
-    return { success: true }
-  } catch (err) {
-    return err;
-  }
+  return { success: true }
 })
 
-app.listen(3000)
+app.addHook('onClose', async function save (app) {
+  const path = await app.orama.save()
+  app.log.info(`Database saved to ${path}`)
+})
+
+app.listen({ port: 3000 })
 ```
 
+### PersistenceInMemory
+
+This plugin comes with a `PersistenceInMemory` class that allows you to persist your data in memory.
+This adapter may be useful for testing purposes, when you need to share the same database instance between multiple tests.
+
+Its constructor accepts the following options:
+
+- `jsonIndex`: The stringified JSON representation of the database instance. Default: `null`
+
+```js
+import Fastify from 'fastify'
+import { fastifyOrama, PersistenceInMemory } from 'fastify-orama'
+
+const appOne = Fastify()
+
+await appOne.register(fastifyOrama, {
+  schema: { author: 'string', quote: 'string' },
+  persistence: new PersistenceInMemory()
+})
+
+// Do some stuff with the database
+await appOne.orama.insert({
+  quote: 'Orama and Fastify are awesome together.',
+  author: 'Mateo Nunez'
+})
+
+const inMemoryDb = await appOne.orama.save()
+
+// Close the Fastify application
+await appOne.close()
+
+
+// Create a new Fastify test case
+const appTwo = Fastify()
+await appTwo.register(fastifyOrama, {
+  persistence: new PersistenceInMemory({
+    jsonIndex: inMemoryDb // Pass the in-memory database to the new Fastify application
+  })
+})
+
+// The database is persisted between Fastify applications
+const results = await appTwo.orama.search({ term: 'Mateo Nunez' })
+```
+
+### Custom persistence
+
+If you need a custom persistence layer, you can implement your own persistence class.
+To do so, you need to implement the following methods:
+
+```js
+const customPersistance = {
+  restore: async function restore () {
+    // Restore the database instance from the persistence layer
+    // Return the database instance or null if it does not exist
+  },
+
+  persist: async function persist (db) {
+    // Persist the database instance to the persistence layer
+    // Whatever this method returns will be passed to the `app.orama.save()` method
+}
+
+await fastify.register(fastifyOrama, {
+  schema,
+  persistence: customPersistance
+})
+```
 
 ## License
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,7 @@ type OramaInstance = {
   schema: Orama['schema'],
 }
 
-declare const FastifyOrama: FastifyPluginCallback<OramaInstance>
+declare const fastifyOrama: FastifyPluginCallback<OramaInstance>
 
 declare module 'fastify' {
   interface FastifyInstance {
@@ -16,5 +16,5 @@ declare module 'fastify' {
   }
 }
 
-export default FastifyOrama
-export { FastifyOrama }
+export default fastifyOrama
+export { fastifyOrama }

--- a/index.js
+++ b/index.js
@@ -25,8 +25,10 @@ async function FastifyOrama (fastify, options) {
   if (persistence) {
     db = await persistence.restore()
 
+    // todo: could we check if the db.schema is the same as the one provided in the options?
+
     oramaApi.save = async function () {
-      await persistence.persist(db)
+      return await persistence.persist(db)
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -27,8 +27,8 @@ async function FastifyOrama (fastify, options) {
 
     // todo: could we check if the db.schema is the same as the one provided in the options?
 
-    oramaApi.save = async function () {
-      return await persistence.persist(db)
+    oramaApi.save = /* async */ function save () {
+      return persistence.persist(db)
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -25,8 +25,6 @@ async function fastifyOrama (fastify, options) {
   if (persistence) {
     db = await persistence.restore()
 
-    // todo: could we check if the db.schema is the same as the one provided in the options?
-
     oramaApi.save = /* async */ function save () {
       return persistence.persist(db)
     }

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ import { create, insert, search } from '@orama/orama' // todo we are limiting th
 import PersistenceInMemory from './lib/persistence/in-memory.js'
 import PersistenceInFile from './lib/persistence/in-file.js'
 
-async function FastifyOrama (fastify, options) {
+async function fastifyOrama (fastify, options) {
   if (fastify.orama) {
     throw new Error('fastify-orama is already registered')
   }
@@ -43,13 +43,13 @@ async function FastifyOrama (fastify, options) {
   fastify.decorate('orama', oramaApi)
 }
 
-export default fp(FastifyOrama, {
+export default fp(fastifyOrama, {
   fastify: '4.x',
   name: 'fastify-orama'
 })
 
 export {
-  FastifyOrama,
+  fastifyOrama,
   PersistenceInMemory,
   PersistenceInFile
 }

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ async function FastifyOrama (fastify, options) {
   }
 
   const {
-    persistence = new PersistenceInMemory(),
+    persistence,
     ...oramaOptions
   } = options
 

--- a/index.js
+++ b/index.js
@@ -1,55 +1,53 @@
 import fp from 'fastify-plugin'
-import { create, insert, search } from '@orama/orama'
-import path from 'path'
-import { existsSync } from 'fs'
-import { restoreFromFile, persistToFile } from '@orama/plugin-data-persistence/server'
+import { create, insert, search } from '@orama/orama' // todo we are limiting the api to the server side
+
+import PersistenceInMemory from './lib/persistence/in-memory.js'
+import PersistenceInFile from './lib/persistence/in-file.js'
 
 async function FastifyOrama (fastify, options) {
-  const {
-    schema,
-    defaultLanguage = 'english',
-    stemming = true,
-    persistence = false
-  } = options
-
   if (fastify.orama) {
     throw new Error('fastify-orama is already registered')
   }
 
+  const {
+    persistence = new PersistenceInMemory(),
+    ...oramaOptions
+  } = options
+
   let db
-  let dbName
-  let dbFormat
+
+  const oramaApi = {
+    insert: (...args) => insert(db, ...args),
+    search: (...args) => search(db, ...args),
+    save: undefined
+  }
 
   if (persistence) {
-    dbName = options.persistency?.name || './orama.json'
-    dbFormat = options.persistency?.format || 'json'
-    const databaseExists = existsSync(path.resolve(dbName))
+    db = await persistence.restore()
 
-    if (!databaseExists) {
-      throw new Error(`The database file ${dbName} does not exist`)
+    oramaApi.save = async function () {
+      await persistence.persist(db)
     }
+  }
 
-    db = await restoreFromFile(dbFormat, `./${dbName}`)
-  } else {
-    if (!schema) {
+  if (!db) {
+    if (!oramaOptions.schema) {
       throw new Error('You must provide a schema to create a new database')
     }
 
-    db = await create({
-      schema,
-      defaultLanguage,
-      stemming
-    })
+    db = await create(oramaOptions)
   }
 
-  fastify.decorate('orama', {
-    insert: (...args) => insert(db, ...args),
-    search: (...args) => search(db, ...args),
-    save: () => persistToFile(db, dbFormat, dbName)
-  })
+  fastify.decorate('orama', oramaApi)
 }
 
 export default fp(FastifyOrama, {
   fastify: '4.x',
-  name: '@fastify/orama'
+  name: 'fastify-orama'
 })
+
+export {
+  FastifyOrama,
+  PersistenceInMemory,
+  PersistenceInFile
+}

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,11 +1,11 @@
 import Fastify from 'fastify'
 import { expectType } from 'tsd'
-import FastifyOrama from '.'
+import fastifyOrama from '.'
 import { Result } from '@orama/orama'
 
 const app = Fastify()
 
-app.register(FastifyOrama, {
+app.register(fastifyOrama, {
   schema: {
     quote: 'string',
     author: 'string'

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,7 +1,9 @@
-import Fastify from 'fastify'
 import { expectType } from 'tsd'
-import fastifyOrama from '.'
+
+import Fastify from 'fastify'
 import { Result } from '@orama/orama'
+
+import { fastifyOrama, PersistenceInMemory, PersistenceInFile } from '.'
 
 const app = Fastify()
 
@@ -10,6 +12,29 @@ app.register(fastifyOrama, {
     quote: 'string',
     author: 'string'
   },
+  prefix: '/api/orama',
+  language: 'en'
+})
+
+app.register(fastifyOrama, {
+  persistence: new PersistenceInMemory()
+})
+
+app.register(fastifyOrama, {
+  persistence: new PersistenceInMemory({
+    jsonIndex: 'index.json'
+  })
+})
+
+app.register(fastifyOrama, {
+  persistence: new PersistenceInFile()
+})
+app.register(fastifyOrama, {
+  persistence: new PersistenceInFile({
+    filePath: 'index.json',
+    format: 'json',
+    mustExistOnStart: true
+  })
 })
 
 app.orama.insert({ quote: 'Hello', author: 'World' })

--- a/lib/persistence/in-file.js
+++ b/lib/persistence/in-file.js
@@ -13,11 +13,11 @@ class PersistenceInFile {
   async restore () {
     const databaseExists = existsSync(path.resolve(this.filePath))
 
-    if (this.mustExistOnStart && !databaseExists) {
-      throw new Error(`The database file ${this.filePath} does not exist`)
-    }
-
     if (!databaseExists) {
+      if (this.mustExistOnStart) {
+        throw new Error(`The database file ${this.filePath} does not exist`)
+      }
+
       return null
     }
 
@@ -25,9 +25,8 @@ class PersistenceInFile {
     return db
   }
 
-  async persist (db) {
-    const filePath = await persistToFile(db, this.format, this.filePath)
-    return filePath
+  /* async */ persist (db) {
+    return persistToFile(db, this.format, this.filePath)
   }
 }
 

--- a/lib/persistence/in-file.js
+++ b/lib/persistence/in-file.js
@@ -1,0 +1,30 @@
+import path from 'node:path'
+import { existsSync } from 'node:fs'
+import { restoreFromFile, persistToFile } from '@orama/plugin-data-persistence/server'
+
+class PersistenceInFile {
+  constructor (options = {}) {
+    this.filePath = options.filePath || path.join(process.cwd(), './orama.msp')
+    this.format = options.format || 'binary'
+
+    this.mustExistOnStart = options.mustExistOnStart || false
+  }
+
+  async restore () {
+    const databaseExists = existsSync(path.resolve(this.filePath))
+
+    if (this.mustExistOnStart && !databaseExists) {
+      throw new Error(`The database file ${this.filePath} does not exist`)
+    }
+
+    const db = await restoreFromFile(this.format, this.filePath)
+    return db
+  }
+
+  async persist (db) {
+    const filePath = await persistToFile(db, this.format, this.filePath)
+    return filePath
+  }
+}
+
+export default PersistenceInFile

--- a/lib/persistence/in-file.js
+++ b/lib/persistence/in-file.js
@@ -7,7 +7,7 @@ class PersistenceInFile {
     this.filePath = options.filePath || path.join(process.cwd(), './orama.msp')
     this.format = options.format || 'binary'
 
-    this.mustExistOnStart = options.mustExistOnStart || false
+    this.mustExistOnStart = options.mustExistOnStart === true || false
   }
 
   async restore () {
@@ -15,6 +15,10 @@ class PersistenceInFile {
 
     if (this.mustExistOnStart && !databaseExists) {
       throw new Error(`The database file ${this.filePath} does not exist`)
+    }
+
+    if (!databaseExists) {
+      return null
     }
 
     const db = await restoreFromFile(this.format, this.filePath)

--- a/lib/persistence/in-memory.js
+++ b/lib/persistence/in-memory.js
@@ -1,8 +1,8 @@
 import { restore, persist } from '@orama/plugin-data-persistence'
 
 class PersistenceInMemory {
-  constructor (options = {}) {
-    this.jsonIndex = options.jsonIndex
+  constructor (options) {
+    this.jsonIndex = options?.jsonIndex
   }
 
   async restore () {

--- a/lib/persistence/in-memory.js
+++ b/lib/persistence/in-memory.js
@@ -5,18 +5,16 @@ class PersistenceInMemory {
     this.jsonIndex = options?.jsonIndex
   }
 
-  async restore () {
+  /* async */ restore () {
     if (!this.jsonIndex) {
       return null
     }
 
-    const db = await restore('json', this.jsonIndex)
-    return db
+    return restore('json', this.jsonIndex)
   }
 
-  async persist (db) {
-    const index = await persist(db, 'json')
-    return index
+  /* async */ persist (db) {
+    return persist(db, 'json')
   }
 }
 

--- a/lib/persistence/in-memory.js
+++ b/lib/persistence/in-memory.js
@@ -1,0 +1,23 @@
+import { restore, persist } from '@orama/plugin-data-persistence'
+
+class PersistenceInMemory {
+  constructor (options = {}) {
+    this.jsonIndex = options.jsonIndex
+  }
+
+  async restore () {
+    if (!this.jsonIndex) {
+      return null
+    }
+
+    const db = await restore('json', this.jsonIndex)
+    return db
+  }
+
+  async persist (db) {
+    const index = await persist(db, 'json')
+    return index
+  }
+}
+
+export default PersistenceInMemory

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "test": "npm run lint && npm run unit && npm run typescript",
     "typescript": "tsd",
     "prepare": "husky install",
-    "unit": "node --test"
+    "preunit": "rm -f *.msp",
+    "unit": "c8 node --test --test-reporter spec"
   },
   "repository": {
     "type": "git",
@@ -42,6 +43,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.5.6",
+    "c8": "^8.0.1",
     "fastify": "^4.21.0",
     "husky": "^8.0.3",
     "snazzy": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -13,10 +13,11 @@
   "scripts": {
     "lint": "standard | snazzy",
     "lint:fix": "standard --fix | snazzy",
+    "pretest": "rm -f *.msp",
     "test": "npm run lint && npm run unit && npm run typescript",
     "typescript": "tsd",
     "prepare": "husky install",
-    "unit": "node --test --test-reporter dot"
+    "unit": "node --test"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -13,12 +13,15 @@
   "scripts": {
     "lint": "standard | snazzy",
     "lint:fix": "standard --fix | snazzy",
-    "pretest": "rm -f *.msp",
+    "pretest": "npm run clean",
     "test": "npm run lint && npm run unit && npm run typescript",
+    "posttest": "npm run clean",
     "typescript": "tsd",
     "prepare": "husky install",
-    "preunit": "rm -f *.msp",
-    "unit": "c8 node --test --test-reporter spec"
+    "clean": "rm -f orama_test* && rm -f *.msp",
+    "preunit": "npm run clean",
+    "unit": "c8 node --test --test-reporter spec",
+    "postunit": "npm run clean"
   },
   "repository": {
     "type": "git",

--- a/test/fastify-orama-persistence.test.js
+++ b/test/fastify-orama-persistence.test.js
@@ -1,9 +1,9 @@
-import { it } from 'node:test'
-import { strictEqual } from 'node:assert'
+import { describe, it } from 'node:test'
+import { strictEqual, match } from 'node:assert'
 import Fastify from 'fastify'
 import { FastifyOrama, PersistenceInMemory, PersistenceInFile } from '../index.js'
-import { create, insert, search } from '@orama/orama'
-import { persistToFile, restoreFromFile } from '@orama/plugin-data-persistence/server'
+import { create, insert } from '@orama/orama'
+import { persistToFile } from '@orama/plugin-data-persistence/server'
 
 async function buildFakeDb (filePath, format) {
   const db = await create({
@@ -26,71 +26,157 @@ async function buildFakeDb (filePath, format) {
   }
 }
 
-it('Should load Orama database from file (binary)', async () => {
-  const opts = await buildFakeDb('./orama.msp', 'binary')
+describe('PersistenceInFile', () => {
+  it('Should load Orama database from file (binary)', async () => {
+    const opts = await buildFakeDb(`./orama_${Date.now()}.msp`, 'binary')
 
-  const fastify = Fastify()
-  await fastify.register(FastifyOrama, {
-    persistence: new PersistenceInFile(opts)
-  })
+    const fastify = Fastify()
+    await fastify.register(FastifyOrama, {
+      persistence: new PersistenceInFile(opts)
+    })
 
-  await fastify.ready()
+    await fastify.ready()
 
-  const results = await fastify.orama.search({ term: 'fastify-orama' })
-  strictEqual(results.count, 1)
-
-  const { document } = results.hits[Object.keys(results.hits)[0]]
-  strictEqual(document.author, 'Mateo Nunez')
-})
-
-it('Should load Orama database from file (json)', async () => {
-  const opts = await buildFakeDb('./orama.json', 'json')
-
-  const fastify = Fastify()
-  await fastify.register(FastifyOrama, {
-    persistence: new PersistenceInFile(opts)
-  })
-
-  await fastify.ready()
-
-  const results = await fastify.orama.search({ term: 'fastify-orama' })
-  strictEqual(results.count, 1)
-
-  const { document } = results.hits[Object.keys(results.hits)[0]]
-  strictEqual(document.author, 'Mateo Nunez')
-})
-
-it('Should save correctly the new database on filesystem when it is created for the first time', async () => {
-  const opts = {
-    filePath: 'can-save.msp',
-    format: 'binary'
-  }
-
-  const fastify = Fastify()
-  await fastify.register(FastifyOrama, {
-    schema: {
-      author: 'string',
-      quote: 'string'
-    },
-    persistence: new PersistenceInFile(opts)
-  })
-
-  await fastify.ready()
-
-  {
-    const results = await fastify.orama.search({ term: 'Mateo Nunez' })
-    strictEqual(results.count, 0)
-  }
-
-  await fastify.orama.insert({
-    quote: 'Orama and Fastify are awesome together.',
-    author: 'Mateo Nunez'
-  })
-
-  await fastify.orama.save()
-
-  {
-    const results = await fastify.orama.search({ term: 'Mateo Nunez' })
+    const results = await fastify.orama.search({ term: 'fastify-orama' })
     strictEqual(results.count, 1)
-  }
+
+    const { document } = results.hits[Object.keys(results.hits)[0]]
+    strictEqual(document.author, 'Mateo Nunez')
+  })
+
+  it('Should load Orama database from file (json)', async () => {
+    const opts = await buildFakeDb(`./orama_${Date.now()}.json`, 'json')
+
+    const fastify = Fastify()
+    await fastify.register(FastifyOrama, {
+      persistence: new PersistenceInFile(opts)
+    })
+
+    await fastify.ready()
+
+    const results = await fastify.orama.search({ term: 'fastify-orama' })
+    strictEqual(results.count, 1)
+
+    const { document } = results.hits[Object.keys(results.hits)[0]]
+    strictEqual(document.author, 'Mateo Nunez')
+  })
+
+  it('Should save correctly the new database on filesystem when it is created for the first time', async () => {
+    const opts = {
+      filePath: 'can-save.msp',
+      format: 'binary'
+    }
+
+    const fastify = Fastify()
+    await fastify.register(FastifyOrama, {
+      schema: { author: 'string', quote: 'string' },
+      persistence: new PersistenceInFile(opts)
+    })
+
+    await fastify.ready()
+
+    {
+      const results = await fastify.orama.search({ term: 'Mateo Nunez' })
+      strictEqual(results.count, 0)
+    }
+
+    await fastify.orama.insert({
+      quote: 'Orama and Fastify are awesome together.',
+      author: 'Mateo Nunez'
+    })
+
+    const path = await fastify.orama.save()
+    strictEqual(path, opts.filePath)
+
+    {
+      const results = await fastify.orama.search({ term: 'Mateo Nunez' })
+      strictEqual(results.count, 1)
+    }
+  })
+
+  it('Should reject when the database file is missing and there is no schema', async () => {
+    try {
+      const fastify = Fastify()
+      await fastify.register(FastifyOrama, {
+        persistence: new PersistenceInFile({ filePath: `${Date.now()}.msp` })
+      })
+    } catch (error) {
+      strictEqual(error.message, 'You must provide a schema to create a new database')
+    }
+  })
+
+  it('Should reject when the database is missing and it is mandatory', async () => {
+    try {
+      const fastify = Fastify()
+      await fastify.register(FastifyOrama, {
+        schema: { author: 'string', quote: 'string' },
+        persistence: new PersistenceInFile({
+          filePath: `${Date.now()}.msp`,
+          mustExistOnStart: true
+        })
+      })
+    } catch (error) {
+      match(error.message, /^The database file .* does not exist$/)
+    }
+  })
+
+  it('Should load the default db name', async () => {
+    await buildFakeDb('./orama.msp', 'binary')
+    const fastify = Fastify()
+    await fastify.register(FastifyOrama, {
+      persistence: new PersistenceInFile({
+        mustExistOnStart: true
+      })
+    })
+
+    await fastify.ready()
+
+    const results = await fastify.orama.search({ term: 'fastify-orama' })
+    strictEqual(results.count, 1)
+  })
+})
+
+describe('PersistenceInMemory', () => {
+  it('Should load Orama database from memory', async () => {
+    const fastify = Fastify()
+    await fastify.register(FastifyOrama, {
+      schema: { author: 'string', quote: 'string' },
+      persistence: new PersistenceInMemory()
+    })
+
+    await fastify.ready()
+
+    {
+      const results = await fastify.orama.search({ term: 'Mateo Nunez' })
+      strictEqual(results.count, 0)
+    }
+
+    await fastify.orama.insert({
+      quote: 'Orama and Fastify are awesome together.',
+      author: 'Mateo Nunez'
+    })
+
+    const inMemoryDb = await fastify.orama.save()
+
+    {
+      const results = await fastify.orama.search({ term: 'Mateo Nunez' })
+      strictEqual(results.count, 1)
+    }
+
+    await fastify.close()
+
+    const fastifyTwo = Fastify()
+    await fastifyTwo.register(FastifyOrama, {
+      persistence: new PersistenceInMemory({
+        jsonIndex: inMemoryDb
+      })
+    })
+
+    await fastifyTwo.ready()
+
+    {
+      const results = await fastifyTwo.orama.search({ term: 'Mateo Nunez' })
+      strictEqual(results.count, 1)
+    }
+  })
 })

--- a/test/fastify-orama-persistence.test.js
+++ b/test/fastify-orama-persistence.test.js
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test'
 import { strictEqual, match } from 'node:assert'
 import Fastify from 'fastify'
-import { FastifyOrama, PersistenceInMemory, PersistenceInFile } from '../index.js'
+import { fastifyOrama, PersistenceInMemory, PersistenceInFile } from '../index.js'
 import { create, insert } from '@orama/orama'
 import { persistToFile } from '@orama/plugin-data-persistence/server'
 
@@ -28,10 +28,10 @@ async function buildFakeDb (filePath, format) {
 
 describe('PersistenceInFile', () => {
   it('Should load Orama database from file (binary)', async () => {
-    const opts = await buildFakeDb(`./orama_${Date.now()}.msp`, 'binary')
+    const opts = await buildFakeDb(`./orama_test_${Date.now()}.msp`, 'binary')
 
     const fastify = Fastify()
-    await fastify.register(FastifyOrama, {
+    await fastify.register(fastifyOrama, {
       persistence: new PersistenceInFile(opts)
     })
 
@@ -45,10 +45,10 @@ describe('PersistenceInFile', () => {
   })
 
   it('Should load Orama database from file (json)', async () => {
-    const opts = await buildFakeDb(`./orama_${Date.now()}.json`, 'json')
+    const opts = await buildFakeDb(`./orama_test_${Date.now()}.json`, 'json')
 
     const fastify = Fastify()
-    await fastify.register(FastifyOrama, {
+    await fastify.register(fastifyOrama, {
       persistence: new PersistenceInFile(opts)
     })
 
@@ -63,12 +63,12 @@ describe('PersistenceInFile', () => {
 
   it('Should save correctly the new database on filesystem when it is created for the first time', async () => {
     const opts = {
-      filePath: 'can-save.msp',
+      filePath: 'orama_test_can-save.msp',
       format: 'binary'
     }
 
     const fastify = Fastify()
-    await fastify.register(FastifyOrama, {
+    await fastify.register(fastifyOrama, {
       schema: { author: 'string', quote: 'string' },
       persistence: new PersistenceInFile(opts)
     })
@@ -97,8 +97,8 @@ describe('PersistenceInFile', () => {
   it('Should reject when the database file is missing and there is no schema', async () => {
     try {
       const fastify = Fastify()
-      await fastify.register(FastifyOrama, {
-        persistence: new PersistenceInFile({ filePath: `${Date.now()}.msp` })
+      await fastify.register(fastifyOrama, {
+        persistence: new PersistenceInFile({ filePath: `orama_test_${Date.now()}.msp` })
       })
     } catch (error) {
       strictEqual(error.message, 'You must provide a schema to create a new database')
@@ -108,10 +108,10 @@ describe('PersistenceInFile', () => {
   it('Should reject when the database is missing and it is mandatory', async () => {
     try {
       const fastify = Fastify()
-      await fastify.register(FastifyOrama, {
+      await fastify.register(fastifyOrama, {
         schema: { author: 'string', quote: 'string' },
         persistence: new PersistenceInFile({
-          filePath: `${Date.now()}.msp`,
+          filePath: `orama_test_${Date.now()}.msp`,
           mustExistOnStart: true
         })
       })
@@ -123,7 +123,7 @@ describe('PersistenceInFile', () => {
   it('Should load the default db name', async () => {
     await buildFakeDb('./orama.msp', 'binary')
     const fastify = Fastify()
-    await fastify.register(FastifyOrama, {
+    await fastify.register(fastifyOrama, {
       persistence: new PersistenceInFile({
         mustExistOnStart: true
       })
@@ -139,7 +139,7 @@ describe('PersistenceInFile', () => {
 describe('PersistenceInMemory', () => {
   it('Should load Orama database from memory', async () => {
     const fastify = Fastify()
-    await fastify.register(FastifyOrama, {
+    await fastify.register(fastifyOrama, {
       schema: { author: 'string', quote: 'string' },
       persistence: new PersistenceInMemory()
     })
@@ -166,7 +166,7 @@ describe('PersistenceInMemory', () => {
     await fastify.close()
 
     const fastifyTwo = Fastify()
-    await fastifyTwo.register(FastifyOrama, {
+    await fastifyTwo.register(fastifyOrama, {
       persistence: new PersistenceInMemory({
         jsonIndex: inMemoryDb
       })

--- a/test/fastify-orama-persistence.test.js
+++ b/test/fastify-orama-persistence.test.js
@@ -1,15 +1,11 @@
-
-import { beforeEach, it, after } from 'node:test'
-import { ok, strictEqual } from 'node:assert'
+import { it } from 'node:test'
+import { strictEqual } from 'node:assert'
 import Fastify from 'fastify'
-import FastifyOrama from '../index.js'
+import { FastifyOrama, PersistenceInMemory, PersistenceInFile } from '../index.js'
 import { create, insert, search } from '@orama/orama'
 import { persistToFile, restoreFromFile } from '@orama/plugin-data-persistence/server'
 
-const dbName = './orama.json'
-const dbFormat = 'json'
-
-beforeEach(async () => {
+async function buildFakeDb (filePath, format) {
   const db = await create({
     schema: {
       author: 'string',
@@ -22,80 +18,79 @@ beforeEach(async () => {
     quote: 'Hi there! This is fastify-orama plugin.'
   })
 
-  await persistToFile(db, dbFormat, dbName)
-})
+  await persistToFile(db, format, filePath)
 
-it('Should load Orama database from file', async () => {
+  return {
+    filePath,
+    format
+  }
+}
+
+it('Should load Orama database from file (binary)', async () => {
+  const opts = await buildFakeDb('./orama.msp', 'binary')
+
   const fastify = Fastify()
   await fastify.register(FastifyOrama, {
-    persistence: true
+    persistence: new PersistenceInFile(opts)
   })
 
-  ok(fastify.orama)
+  await fastify.ready()
+
+  const results = await fastify.orama.search({ term: 'fastify-orama' })
+  strictEqual(results.count, 1)
+
+  const { document } = results.hits[Object.keys(results.hits)[0]]
+  strictEqual(document.author, 'Mateo Nunez')
 })
 
-// it('Should retrieve search results loading Orama database from file', async () => {
-//   after(() => {
-//     fastify.close()
-//   })
+it('Should load Orama database from file (json)', async () => {
+  const opts = await buildFakeDb('./orama.json', 'json')
 
-//   const fastify = Fastify()
-//   await fastify.register(FastifyOrama, {
-//     persistence: true
-//   })
-//   const results = await fastify.orama.search({
-//     term: 'fastify-orama'
-//   })
+  const fastify = Fastify()
+  await fastify.register(FastifyOrama, {
+    persistence: new PersistenceInFile(opts)
+  })
 
-//   strictEqual(results.count, 1)
+  await fastify.ready()
 
-//   const { document } = results.hits[Object.keys(results.hits)[0]]
-//   strictEqual(document.author, 'Mateo Nunez')
-// })
+  const results = await fastify.orama.search({ term: 'fastify-orama' })
+  strictEqual(results.count, 1)
 
-// it('Should save correctly the new database on filesystem', async () => {
-//   after(() => {
-//     fastify.close()
-//   })
+  const { document } = results.hits[Object.keys(results.hits)[0]]
+  strictEqual(document.author, 'Mateo Nunez')
+})
 
-//   const fastify = Fastify()
-//   await fastify.register(FastifyOrama, {
-//     persistence: true
-//   })
+it('Should save correctly the new database on filesystem when it is created for the first time', async () => {
+  const opts = {
+    filePath: 'can-save.msp',
+    format: 'binary'
+  }
 
-//   await fastify.orama.insert({
-//     quote: 'Orama and Fastify are awesome together.',
-//     author: 'Mateo Nunez'
-//   })
+  const fastify = Fastify()
+  await fastify.register(FastifyOrama, {
+    schema: {
+      author: 'string',
+      quote: 'string'
+    },
+    persistence: new PersistenceInFile(opts)
+  })
 
-//   await fastify.orama.save()
-//   const db2 = await restoreFromFile(dbFormat, dbName)
-//   const results = await search(db2, {
-//     term: 'Mateo Nunez'
-//   })
+  await fastify.ready()
 
-//   strictEqual(results.count, 2)
-// })
+  {
+    const results = await fastify.orama.search({ term: 'Mateo Nunez' })
+    strictEqual(results.count, 0)
+  }
 
-// it("Should thrown an error when database persitent doesn't exists", async () => {
-//   after(() => {
-//     fastify.close()
-//   })
+  await fastify.orama.insert({
+    quote: 'Orama and Fastify are awesome together.',
+    author: 'Mateo Nunez'
+  })
 
-//   const fastify = Fastify()
-//   const databaseName = './nope.json'
+  await fastify.orama.save()
 
-//   try {
-//     await fastify.register(FastifyOrama, {
-//       persistence: true,
-//       persistency: {
-//         name: databaseName
-//       }
-//     })
-//   } catch (error) {
-//     strictEqual(
-//       error.message,
-//       `The database file ${databaseName} does not exist`
-//     )
-//   }
-// })
+  {
+    const results = await fastify.orama.search({ term: 'Mateo Nunez' })
+    strictEqual(results.count, 1)
+  }
+})

--- a/test/fastify-orama-persistence.test.js
+++ b/test/fastify-orama-persistence.test.js
@@ -1,4 +1,3 @@
-'use strict'
 
 import { beforeEach, it, after } from 'node:test'
 import { ok, strictEqual } from 'node:assert'
@@ -27,10 +26,6 @@ beforeEach(async () => {
 })
 
 it('Should load Orama database from file', async () => {
-  after(() => {
-    fastify.close()
-  })
-
   const fastify = Fastify()
   await fastify.register(FastifyOrama, {
     persistence: true
@@ -39,68 +34,68 @@ it('Should load Orama database from file', async () => {
   ok(fastify.orama)
 })
 
-it('Should retrieve search results loading Orama database from file', async () => {
-  after(() => {
-    fastify.close()
-  })
+// it('Should retrieve search results loading Orama database from file', async () => {
+//   after(() => {
+//     fastify.close()
+//   })
 
-  const fastify = Fastify()
-  await fastify.register(FastifyOrama, {
-    persistence: true
-  })
-  const results = await fastify.orama.search({
-    term: 'fastify-orama'
-  })
+//   const fastify = Fastify()
+//   await fastify.register(FastifyOrama, {
+//     persistence: true
+//   })
+//   const results = await fastify.orama.search({
+//     term: 'fastify-orama'
+//   })
 
-  strictEqual(results.count, 1)
+//   strictEqual(results.count, 1)
 
-  const { document } = results.hits[Object.keys(results.hits)[0]]
-  strictEqual(document.author, 'Mateo Nunez')
-})
+//   const { document } = results.hits[Object.keys(results.hits)[0]]
+//   strictEqual(document.author, 'Mateo Nunez')
+// })
 
-it('Should save correctly the new database on filesystem', async () => {
-  after(() => {
-    fastify.close()
-  })
+// it('Should save correctly the new database on filesystem', async () => {
+//   after(() => {
+//     fastify.close()
+//   })
 
-  const fastify = Fastify()
-  await fastify.register(FastifyOrama, {
-    persistence: true
-  })
+//   const fastify = Fastify()
+//   await fastify.register(FastifyOrama, {
+//     persistence: true
+//   })
 
-  await fastify.orama.insert({
-    quote: 'Orama and Fastify are awesome together.',
-    author: 'Mateo Nunez'
-  })
+//   await fastify.orama.insert({
+//     quote: 'Orama and Fastify are awesome together.',
+//     author: 'Mateo Nunez'
+//   })
 
-  await fastify.orama.save()
-  const db2 = await restoreFromFile(dbFormat, dbName)
-  const results = await search(db2, {
-    term: 'Mateo Nunez'
-  })
+//   await fastify.orama.save()
+//   const db2 = await restoreFromFile(dbFormat, dbName)
+//   const results = await search(db2, {
+//     term: 'Mateo Nunez'
+//   })
 
-  strictEqual(results.count, 2)
-})
+//   strictEqual(results.count, 2)
+// })
 
-it("Should thrown an error when database persitent doesn't exists", async () => {
-  after(() => {
-    fastify.close()
-  })
+// it("Should thrown an error when database persitent doesn't exists", async () => {
+//   after(() => {
+//     fastify.close()
+//   })
 
-  const fastify = Fastify()
-  const databaseName = './nope.json'
+//   const fastify = Fastify()
+//   const databaseName = './nope.json'
 
-  try {
-    await fastify.register(FastifyOrama, {
-      persistence: true,
-      persistency: {
-        name: databaseName
-      }
-    })
-  } catch (error) {
-    strictEqual(
-      error.message,
-      `The database file ${databaseName} does not exist`
-    )
-  }
-})
+//   try {
+//     await fastify.register(FastifyOrama, {
+//       persistence: true,
+//       persistency: {
+//         name: databaseName
+//       }
+//     })
+//   } catch (error) {
+//     strictEqual(
+//       error.message,
+//       `The database file ${databaseName} does not exist`
+//     )
+//   }
+// })

--- a/test/fastify-orama-persistence.test.js
+++ b/test/fastify-orama-persistence.test.js
@@ -138,32 +138,32 @@ describe('PersistenceInFile', () => {
 
 describe('PersistenceInMemory', () => {
   it('Should load Orama database from memory', async () => {
-    const fastify = Fastify()
-    await fastify.register(fastifyOrama, {
+    const fastifyOne = Fastify()
+    await fastifyOne.register(fastifyOrama, {
       schema: { author: 'string', quote: 'string' },
       persistence: new PersistenceInMemory()
     })
 
-    await fastify.ready()
+    await fastifyOne.ready()
 
     {
-      const results = await fastify.orama.search({ term: 'Mateo Nunez' })
+      const results = await fastifyOne.orama.search({ term: 'Mateo Nunez' })
       strictEqual(results.count, 0)
     }
 
-    await fastify.orama.insert({
+    await fastifyOne.orama.insert({
       quote: 'Orama and Fastify are awesome together.',
       author: 'Mateo Nunez'
     })
 
-    const inMemoryDb = await fastify.orama.save()
+    const inMemoryDb = await fastifyOne.orama.save()
 
     {
-      const results = await fastify.orama.search({ term: 'Mateo Nunez' })
+      const results = await fastifyOne.orama.search({ term: 'Mateo Nunez' })
       strictEqual(results.count, 1)
     }
 
-    await fastify.close()
+    await fastifyOne.close()
 
     const fastifyTwo = Fastify()
     await fastifyTwo.register(fastifyOrama, {

--- a/test/fastify-orama.test.js
+++ b/test/fastify-orama.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-import { it, after } from 'node:test'
+import { it } from 'node:test'
 import { ok, strictEqual } from 'node:assert'
 import Fastify from 'fastify'
 import FastifyOrama from '../index.js'
@@ -15,6 +15,7 @@ it('Should register correctly FastifyOrama plugin', async () => {
   })
 
   ok(fastify.orama)
+  ok(fastify.orama.save === undefined)
 })
 
 it('Should insert and retrieve data using Orama', async () => {

--- a/test/fastify-orama.test.js
+++ b/test/fastify-orama.test.js
@@ -3,11 +3,11 @@
 import { it } from 'node:test'
 import { ok, strictEqual } from 'node:assert'
 import Fastify from 'fastify'
-import FastifyOrama from '../index.js'
+import fastifyOrama from '../index.js'
 
-it('Should register correctly FastifyOrama plugin', async () => {
+it('Should register correctly fastifyOrama plugin', async () => {
   const fastify = Fastify()
-  await fastify.register(FastifyOrama, {
+  await fastify.register(fastifyOrama, {
     schema: {
       quote: 'string',
       author: 'string'
@@ -21,7 +21,7 @@ it('Should register correctly FastifyOrama plugin', async () => {
 it('Should insert and retrieve data using Orama', async () => {
   const fastify = Fastify()
 
-  await fastify.register(FastifyOrama, {
+  await fastify.register(fastifyOrama, {
     schema: {
       quote: 'string',
       author: 'string'
@@ -45,7 +45,7 @@ it('Should throw an error when the schema is not declared', async () => {
   const fastify = Fastify()
 
   try {
-    await fastify.register(FastifyOrama)
+    await fastify.register(fastifyOrama)
   } catch (error) {
     strictEqual(error.message, 'You must provide a schema to create a new database')
   }
@@ -55,14 +55,14 @@ it('Should throw when trying to register multiple instances without giving a nam
   const fastify = Fastify()
 
   try {
-    await fastify.register(FastifyOrama, {
+    await fastify.register(fastifyOrama, {
       schema: {
         quote: 'string',
         author: 'string'
       }
     })
 
-    await fastify.register(FastifyOrama, {
+    await fastify.register(fastifyOrama, {
       schema: {
         anotherColumn: 'string',
         antoherHere: 'string'

--- a/test/fastify-orama.test.js
+++ b/test/fastify-orama.test.js
@@ -5,11 +5,7 @@ import { ok, strictEqual } from 'node:assert'
 import Fastify from 'fastify'
 import FastifyOrama from '../index.js'
 
-it('Should exists correctly FastifyOrama plugin', async () => {
-  after(() => {
-    fastify.close()
-  })
-
+it('Should register correctly FastifyOrama plugin', async () => {
   const fastify = Fastify()
   await fastify.register(FastifyOrama, {
     schema: {
@@ -22,10 +18,6 @@ it('Should exists correctly FastifyOrama plugin', async () => {
 })
 
 it('Should insert and retrieve data using Orama', async () => {
-  after(() => {
-    fastify.close()
-  })
-
   const fastify = Fastify()
 
   await fastify.register(FastifyOrama, {
@@ -49,10 +41,6 @@ it('Should insert and retrieve data using Orama', async () => {
 })
 
 it('Should throw an error when the schema is not declared', async () => {
-  after(() => {
-    fastify.close()
-  })
-
   const fastify = Fastify()
 
   try {
@@ -63,10 +51,6 @@ it('Should throw an error when the schema is not declared', async () => {
 })
 
 it('Should throw when trying to register multiple instances without giving a name', async () => {
-  after(() => {
-    fastify.close()
-  })
-
   const fastify = Fastify()
 
   try {


### PR DESCRIPTION
closes #153
closes #150

```
-------------------------------|---------|----------|---------|---------|-------------------
File                           | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-------------------------------|---------|----------|---------|---------|-------------------
All files                      |     100 |      100 |     100 |     100 |                   
 fastify-orama                 |     100 |      100 |     100 |     100 |                   
  index.js                     |     100 |      100 |     100 |     100 |                   
 fastify-orama/lib/persistence |     100 |      100 |     100 |     100 |                   
  in-file.js                   |     100 |      100 |     100 |     100 |                   
  in-memory.js                 |     100 |      100 |     100 |     100 |                   
-------------------------------|---------|----------|---------|---------|-------------------
```

main changes:

- rename the plugin to `fastify-orama`. The `@fastify/` namespace should be used for official ones
- new persistence API - docs soon
- propagate all the option to orama so we are not hiding new cool features

TODO:

- [x] docs
- [x] ts 🤢 <---- not sure I will do it. LOL tsd is passing..