### PR TITLE
refactor: review typescript signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,58 @@ app.get('/genId', async function handler (req, reply) {
 })
 ```
 
+## Typescript
+
+This plugin comes with Typescript support out of the box.
+Using the `withOrama` helper, you can access the `orama` decorator in your Fastify application with the correct schema.
+
+```ts
+import Fastify from 'fastify'
+
+import { PersistenceInMemory, fastifyOrama } from 'fastify-orama'
+
+const app = Fastify()
+
+const mySchema = {
+  quote: 'string',
+  author: 'string'
+} as const
+
+await app.register(fastifyOrama, {
+  schema: mySchema,
+  persistence: new PersistenceInMemory()
+})
+
+const appWithOrama = app.withOrama<typeof mySchema>()
+const id = await appWithOrama.orama.insert({ quote: 'Hello', author: 'World' })
+
+appWithOrama.get('/hello', async () => {
+
+  const {orama} = appWithOrama
+  const result = await orama.search({ term: 'hello' })
+
+  return {
+    hello: result.hits
+  }
+})
+```
+
+Usage with `fastify-plugin`:
+
+```ts
+import fp from 'fastify-plugin'
+
+fp(function plugins(fastify) {
+  const fastifyWithOrama = fastify.withOrama<typeof mySchema>()
+
+  expectType<{
+    insert: (document: PartialSchemaDeep<TypedDocument<Orama<typeof mySchema>>>) => Promise<string>,
+    search: (params: SearchParams<Orama<Schema<typeof mySchema>>, typeof mySchema>) => Promise<Results<Schema<typeof mySchema>>>,
+    persist?: () => Promise<any>,
+  }>(fastifyWithOrama.orama)
+})
+```
+
 ## License
 
 fastifyOrama is licensed under the [MIT](LICENSE) license.

--- a/index.d.ts
+++ b/index.d.ts
@@ -31,13 +31,17 @@ type FastifyOramaPluginOptions = {
 
 declare const fastifyOrama: FastifyPluginCallback<FastifyOramaPluginOptions>
 
+interface OramaApi<T> {
+  insert: (document: PartialSchemaDeep<TypedDocument<Orama<T>>>) => Promise<string>,
+  search: (params: SearchParams<Orama<Schema<T>>, T>) => Promise<Results<Schema<T>>>,
+  persist?: () => Promise<any>,
+}
+
 declare module 'fastify' {
   interface FastifyInstance {
-    getOrama<T>(): {
-      insert: (document: PartialSchemaDeep<TypedDocument<Orama<T>>>) => Promise<string>,
-      search: (params: SearchParams<Orama<Schema<T>>, T>) => Promise<Results<Schema<T>>>,
-      persist?: () => Promise<any>,
-    }
+    withOrama<T>(): this & {
+      orama: OramaApi<T>
+    };
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ async function fastifyOrama (fastify, options) {
   }
 
   function withOrama () {
-    return fastify
+    return this
   }
 
   fastify.decorate('orama', oramaApi)

--- a/index.js
+++ b/index.js
@@ -51,7 +51,12 @@ async function fastifyOrama (fastify, options) {
     db = await Orama.create(oramaOptions)
   }
 
+  function withOrama () {
+    return fastify
+  }
+
   fastify.decorate('orama', oramaApi)
+  fastify.decorate('withOrama', withOrama)
 }
 
 module.exports = fp(fastifyOrama, {

--- a/index.js
+++ b/index.js
@@ -52,9 +52,6 @@ async function fastifyOrama (fastify, options) {
   }
 
   fastify.decorate('orama', oramaApi)
-  fastify.decorate('getOrama', function () {
-    return oramaApi
-  })
 }
 
 module.exports = fp(fastifyOrama, {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,9 +1,9 @@
-import { expectType } from 'tsd'
+import {expectType} from 'tsd'
 
+import {InternalTypedDocument, Orama, PartialSchemaDeep, Results, Schema, SearchParams, TypedDocument} from '@orama/orama'
 import Fastify from 'fastify'
-import { TypedDocument, Orama, Results, Schema, InternalTypedDocument } from '@orama/orama'
 
-import { fastifyOrama, PersistenceInMemory, PersistenceInFile } from '.'
+import {PersistenceInFile, PersistenceInMemory, fastifyOrama} from '.'
 
 const app = Fastify()
 
@@ -41,13 +41,13 @@ app.register(fastifyOrama, {
   })
 })
 
-const orama = app.getOrama<typeof mySchema>()
-const id = await orama.insert({ quote: 'Hello', author: 'World' })
+const appWithOrama = app.withOrama<typeof mySchema>()
+const id = await appWithOrama.orama.insert({ quote: 'Hello', author: 'World' })
 expectType<string>(id)
 
 app.get('/hello', async () => {
 
-  const orama = app.getOrama<typeof mySchema>()
+  const {orama} = appWithOrama
   const result = await orama.search({ term: 'hello' })
 
   expectType<Results<InternalTypedDocument<MySchema>>>(result)
@@ -57,3 +57,9 @@ app.get('/hello', async () => {
     hello: result.hits
   }
 })
+
+expectType<{
+  insert: (document: PartialSchemaDeep<TypedDocument<Orama<typeof mySchema>>>) => Promise<string>,
+  search: (params: SearchParams<Orama<Schema<typeof mySchema>>, typeof mySchema>) => Promise<Results<Schema<typeof mySchema>>>,
+  persist?: () => Promise<any>,
+}>(appWithOrama.orama)

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -45,7 +45,7 @@ const appWithOrama = app.withOrama<typeof mySchema>()
 const id = await appWithOrama.orama.insert({ quote: 'Hello', author: 'World' })
 expectType<string>(id)
 
-app.get('/hello', async () => {
+appWithOrama.get('/hello', async () => {
 
   const {orama} = appWithOrama
   const result = await orama.search({ term: 'hello' })

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "standard | snazzy",
     "lint:fix": "standard --fix | snazzy",
     "pretest": "npm run clean",
-    "test": "npm run lint && npm run unit && npm run typescript",
+    "test": "npm run lint && npm run unit && npm run typescript && ts-node test/types/index.ts",
     "posttest": "npm run clean",
     "typescript": "tsd",
     "prepare": "husky install",
@@ -50,10 +50,14 @@
     "husky": "^8.0.3",
     "snazzy": "^9.0.0",
     "standard": "^17.1.0",
+    "ts-node": "^10.9.1",
     "tsd": "^0.29.0",
     "typescript": "^5.2.2"
   },
   "publishConfig": {
     "access": "public"
+  },
+  "tsd": {
+    "directory": "test/types"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -72,3 +72,18 @@ it('Should throw when trying to register multiple instances without giving a nam
     strictEqual(error.message, 'fastify-orama is already registered')
   }
 })
+
+it('Expose a withOrama function', async () => {
+  const fastify = Fastify()
+
+  await fastify.register(fastifyOrama, {
+    schema: {
+      quote: 'string',
+      author: 'string'
+    }
+  })
+
+  const withOrama = fastify.withOrama()
+
+  strictEqual(fastify.orama, withOrama.orama)
+})

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -72,16 +72,3 @@ it('Should throw when trying to register multiple instances without giving a nam
     strictEqual(error.message, 'fastify-orama is already registered')
   }
 })
-
-it('Expose a getOrama function', async () => {
-  const fastify = Fastify()
-
-  await fastify.register(fastifyOrama, {
-    schema: {
-      quote: 'string',
-      author: 'string'
-    }
-  })
-
-  strictEqual(fastify.orama, fastify.getOrama())
-})

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -1,6 +1,6 @@
-import {expectType} from 'tsd'
+import { expectType } from 'tsd'
 
-import {InternalTypedDocument, Orama, PartialSchemaDeep, Results, Schema, SearchParams, TypedDocument} from '@orama/orama'
+import { InternalTypedDocument, Orama, PartialSchemaDeep, Results, Schema, SearchParams, TypedDocument } from '@orama/orama'
 import Fastify from 'fastify'
 
 import {PersistenceInFile, PersistenceInMemory, fastifyOrama} from '../..'

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -3,7 +3,7 @@ import {expectType} from 'tsd'
 import {InternalTypedDocument, Orama, PartialSchemaDeep, Results, Schema, SearchParams, TypedDocument} from '@orama/orama'
 import Fastify from 'fastify'
 
-import {PersistenceInFile, PersistenceInMemory, fastifyOrama} from '.'
+import {PersistenceInFile, PersistenceInMemory, fastifyOrama} from '../..'
 
 const app = Fastify()
 

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -2,8 +2,9 @@ import { expectType } from 'tsd'
 
 import { InternalTypedDocument, Orama, PartialSchemaDeep, Results, Schema, SearchParams, TypedDocument } from '@orama/orama'
 import Fastify from 'fastify'
+import fp from 'fastify-plugin'
 
-import {PersistenceInFile, PersistenceInMemory, fastifyOrama} from '../..'
+import { PersistenceInFile, PersistenceInMemory, fastifyOrama } from '../..'
 
 const app = Fastify()
 
@@ -63,3 +64,13 @@ expectType<{
   search: (params: SearchParams<Orama<Schema<typeof mySchema>>, typeof mySchema>) => Promise<Results<Schema<typeof mySchema>>>,
   persist?: () => Promise<any>,
 }>(appWithOrama.orama)
+
+fp(function(fastify) {
+  const fastifyWithOrama = fastify.withOrama<typeof mySchema>()
+
+  expectType<{
+    insert: (document: PartialSchemaDeep<TypedDocument<Orama<typeof mySchema>>>) => Promise<string>,
+    search: (params: SearchParams<Orama<Schema<typeof mySchema>>, typeof mySchema>) => Promise<Results<Schema<typeof mySchema>>>,
+    persist?: () => Promise<any>,
+  }>(fastifyWithOrama.orama)
+})

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -1,4 +1,3 @@
-import {Schema} from '@orama/orama'
 import Fastify from 'fastify'
 
 import {PersistenceInMemory, fastifyOrama} from '../..'

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -1,6 +1,6 @@
 import Fastify from 'fastify'
 
-import {PersistenceInMemory, fastifyOrama} from '../..'
+import { PersistenceInMemory, fastifyOrama } from '../..'
 
 (async function () {
   const app = Fastify()

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -1,0 +1,31 @@
+import {Schema} from '@orama/orama'
+import Fastify from 'fastify'
+
+import {PersistenceInMemory, fastifyOrama} from '../..'
+
+(async function () {
+  const app = Fastify()
+
+  const mySchema = {
+    quote: 'string',
+    author: 'string'
+  } as const
+
+  await app.register(fastifyOrama, {
+    schema: mySchema,
+    persistence: new PersistenceInMemory()
+  })
+
+  const appWithOrama = app.withOrama<typeof mySchema>()
+  const id = await appWithOrama.orama.insert({ quote: 'Hello', author: 'World' })
+
+  appWithOrama.get('/hello', async () => {
+
+    const {orama} = appWithOrama
+    const result = await orama.search({ term: 'hello' })
+
+    return {
+      hello: result.hits
+    }
+  })
+})();


### PR DESCRIPTION
@Eomm and @mateonunez, I reviewed a little the typescript interface and removed the `getOrama` method.
In this way, there is only one decorator, and if someone wants to use typescript, using the `withOrama<T>()` get the FastifyInstance with the correct type and with the `orama` decorator set up.