### PR TITLE
major: upgrade to fastify v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20]
+        node-version: [20, 22]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,14 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     strategy:
       matrix:
         node-version: [20, 22]
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   test:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         node-version: [20, 22]

--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@
 npm install fastify-orama
 ```
 
+### Compatibility
+
+| Plugin version | Fastify version | Orama version |
+| ------------- |:---------------:|------------:|
+| `^2.0.0` | `^5.0.0` | `^2.0.0` |
+| `^1.0.0` | `^4.0.0` | `^2.0.0` |
+
 ****
 
 

--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ async function fastifyOrama (fastify, options) {
 }
 
 module.exports = fp(fastifyOrama, {
-  fastify: '4.x',
+  fastify: '5.x',
   name: 'fastify-orama'
 })
 

--- a/package.json
+++ b/package.json
@@ -41,12 +41,12 @@
   "dependencies": {
     "@orama/orama": "^2.0.0",
     "@orama/plugin-data-persistence": "^2.0.0",
-    "fastify-plugin": "^4.5.1"
+    "fastify-plugin": "^5.0.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
     "c8": "^10.0.0",
-    "fastify": "^4.24.2",
+    "fastify": "^5.0.0",
     "husky": "^9.0.5",
     "snazzy": "^9.0.0",
     "standard": "^17.1.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "esModuleInterop": true,
+  },
+}


### PR DESCRIPTION
As titled

I think we should ship this module with orama 2 and then bump a new major when we will upgrade to orama 3.

Closes #180 
Closes #178 