### PR TITLE
chore: move from tsd to tstyche

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "posttest": "npm run clean",
     "typescript": "tsd",
     "prepare": "husky",
+    "posttypescript": "tstyche",
     "clean": "rm -f orama_test* && rm -f *.msp",
     "preunit": "npm run clean",
     "unit": "c8 node --test --test-reporter spec",
@@ -52,6 +53,7 @@
     "standard": "^17.1.2",
     "ts-node": "^10.9.2",
     "tsd": "^0.32.0",
+    "tstyche": "^4.0.2",
     "typescript": "^5.8.3"
   },
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -15,9 +15,8 @@
     "pretest": "npm run clean",
     "test": "npm run lint && npm run unit && npm run typescript && ts-node test/types/index.ts",
     "posttest": "npm run clean",
-    "typescript": "tsd",
+    "typescript": "tstyche",
     "prepare": "husky",
-    "posttypescript": "tstyche",
     "clean": "rm -f orama_test* && rm -f *.msp",
     "preunit": "npm run clean",
     "unit": "c8 node --test --test-reporter spec",
@@ -52,15 +51,11 @@
     "snazzy": "^9.0.0",
     "standard": "^17.1.2",
     "ts-node": "^10.9.2",
-    "tsd": "^0.32.0",
     "tstyche": "^4.0.2",
     "typescript": "^5.8.3"
   },
   "publishConfig": {
     "access": "public"
-  },
-  "tsd": {
-    "directory": "test/types"
   },
   "packageManager": "pnpm@10.8.1+sha512.c50088ba998c67b8ca8c99df8a5e02fd2ae2e2b29aaf238feaa9e124248d3f48f9fb6db2424949ff901cffbb5e0f0cc1ad6aedb602cd29450751d11c35023677"
 }

--- a/test/types/index.tst.ts
+++ b/test/types/index.tst.ts
@@ -1,4 +1,4 @@
-import { expectType } from 'tsd'
+import { expect } from 'tstyche'
 
 import { InternalTypedDocument, Orama, PartialSchemaDeep, Results, Schema, SearchParams, TypedDocument } from '@orama/orama'
 import Fastify from 'fastify'
@@ -44,7 +44,7 @@ app.register(fastifyOrama, {
 
 const appWithOrama = app.withOrama<typeof mySchema>()
 appWithOrama.orama.insert({ quote: 'Hello', author: 'World' }).then(id => {
-  expectType<string>(id)
+  expect(id).type.toBe<string>()
 })
 
 appWithOrama.get('/hello', async () => {
@@ -52,26 +52,26 @@ appWithOrama.get('/hello', async () => {
   const {orama} = appWithOrama
   const result = await orama.search({ term: 'hello' })
 
-  expectType<Results<InternalTypedDocument<MySchema>>>(result)
-  expectType<string>(result.hits[0].document.author)
+  expect(result).type.toBe<Results<InternalTypedDocument<MySchema>>>()
+  expect(result.hits[0].document.author).type.toBe<string>()
 
   return {
     hello: result.hits
   }
 })
 
-expectType<{
+expect(appWithOrama.orama).type.toBe<{
   insert: (document: PartialSchemaDeep<TypedDocument<Orama<typeof mySchema>>>) => Promise<string>,
   search: (params: SearchParams<Orama<Schema<typeof mySchema>>, typeof mySchema>) => Promise<Results<Schema<typeof mySchema>>>,
   persist?: () => Promise<any>,
-}>(appWithOrama.orama)
+}>()
 
 fp(function(fastify) {
   const fastifyWithOrama = fastify.withOrama<typeof mySchema>()
 
-  expectType<{
+  expect(fastifyWithOrama.orama).type.toBe<{
     insert: (document: PartialSchemaDeep<TypedDocument<Orama<typeof mySchema>>>) => Promise<string>,
     search: (params: SearchParams<Orama<Schema<typeof mySchema>>, typeof mySchema>) => Promise<Results<Schema<typeof mySchema>>>,
     persist?: () => Promise<any>,
-  }>(fastifyWithOrama.orama)
+  }>()
 })

--- a/test/types/index.tst.ts
+++ b/test/types/index.tst.ts
@@ -1,4 +1,4 @@
-import { expect } from 'tstyche'
+import { expect, test } from 'tstyche'
 
 import { InternalTypedDocument, Orama, PartialSchemaDeep, Results, Schema, SearchParams, TypedDocument } from '@orama/orama'
 import Fastify from 'fastify'
@@ -43,35 +43,45 @@ app.register(fastifyOrama, {
 })
 
 const appWithOrama = app.withOrama<typeof mySchema>()
-appWithOrama.orama.insert({ quote: 'Hello', author: 'World' }).then(id => {
-  expect(id).type.toBe<string>()
+
+test('should enable the insertion of documents', () => {
+  appWithOrama.orama.insert({ quote: 'Hello', author: 'World' }).then(id => {
+    expect(id).type.toBe<string>()
+  })
 })
 
-appWithOrama.get('/hello', async () => {
+test('should enable the searching of documents', () => {
+  appWithOrama.get('/hello', async () => {
 
-  const {orama} = appWithOrama
-  const result = await orama.search({ term: 'hello' })
+    const {orama} = appWithOrama
+    const result = await orama.search({ term: 'hello' })
 
-  expect(result).type.toBe<Results<InternalTypedDocument<MySchema>>>()
-  expect(result.hits[0].document.author).type.toBe<string>()
+    expect(result).type.toBe<Results<InternalTypedDocument<MySchema>>>()
+    expect(result.hits[0].document.author).type.toBe<string>()
 
-  return {
-    hello: result.hits
-  }
+    return {
+      hello: result.hits
+    }
+  })
 })
 
-expect(appWithOrama.orama).type.toBe<{
-  insert: (document: PartialSchemaDeep<TypedDocument<Orama<typeof mySchema>>>) => Promise<string>,
-  search: (params: SearchParams<Orama<Schema<typeof mySchema>>, typeof mySchema>) => Promise<Results<Schema<typeof mySchema>>>,
-  persist?: () => Promise<any>,
-}>()
-
-fp(function(fastify) {
-  const fastifyWithOrama = fastify.withOrama<typeof mySchema>()
-
-  expect(fastifyWithOrama.orama).type.toBe<{
+test('should expose the Orama API', () => {
+  expect(appWithOrama.orama).type.toBe<{
     insert: (document: PartialSchemaDeep<TypedDocument<Orama<typeof mySchema>>>) => Promise<string>,
     search: (params: SearchParams<Orama<Schema<typeof mySchema>>, typeof mySchema>) => Promise<Results<Schema<typeof mySchema>>>,
     persist?: () => Promise<any>,
   }>()
+})
+
+
+test('should enable the withOrama method', () => {
+  fp(function(fastify) {
+    const fastifyWithOrama = fastify.withOrama<typeof mySchema>()
+
+    expect(fastifyWithOrama.orama).type.toBe<{
+      insert: (document: PartialSchemaDeep<TypedDocument<Orama<typeof mySchema>>>) => Promise<string>,
+      search: (params: SearchParams<Orama<Schema<typeof mySchema>>, typeof mySchema>) => Promise<Results<Schema<typeof mySchema>>>,
+      persist?: () => Promise<any>,
+    }>()
+  })
 })


### PR DESCRIPTION
Hi, I created this PR to move from `tsd` to `tstyche`.
`tsd` looks abandoned, and `tstyche` has better integration with the new node test runner and better reporting.

Here is the example.
<img width="806" alt="Screenshot 2025-06-23 at 21 30 04" src="https://github.com/user-attachments/assets/cd183df7-f0e5-4e3d-8d5b-34fd7dcff03a" />

Feel free to comment or merge if it is helpful for the project.